### PR TITLE
ci: 🎡 Renovate の設定を bun ベースに修正した

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,37 +1,46 @@
 name: ⏰ Renovate
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 on:
   workflow_dispatch:
   schedule:
     - cron: '00 00,12 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
 env:
+  LANG: ja_JP.UTF-8
   TZ: Asia/Tokyo
 
 permissions: write-all
+
 jobs:
   renovate:
     name: Renovate を実行する
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - name: コードをチェックアウトする
+      - name: $ git clone する
+        # https://github.com/actions/checkout/releases
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
-          version: 9.0.4
+          persist-credentials: false
+      - name: bun のセットアップを行う
+        # https://github.com/oven-sh/setup-bun/releases
+        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+        # with:
+        #   bun-version: 1.2.8 # or "latest", "canary", <sha>
       - name: Node.js のセットアップを行う
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version-file: '.node-version'
-          cache: pnpm
-      - name: Node のパッケージをインストールする
-        run: |
-          pnpm install
+      - name: package.json の依存関係をインストールする ($ bun install)
+        run: bun install --frozen-lockfile
       - name: Renovate を実行する
         uses: renovatebot/github-action@c21017a4a2fc9f42953bcc907e375a5a544557ec # v41.0.18
         with:


### PR DESCRIPTION
This pull request includes several updates to the `.github/workflows/renovate.yml` file to improve the workflow configuration and dependencies. The most important changes include adding default shell settings, updating environment variables, and modifying the setup steps for dependencies.

Workflow configuration updates:

* Added default shell settings to use bash. (`.github/workflows/renovate.yml` [.github/workflows/renovate.ymlL3-R43](diffhunk://#diff-2f2dcee4f3f279ea8d2f4cd0235f2ab917d8cf1d8e11f4f195a3816afe79af26L3-R43))
* Updated environment variables to set the language to Japanese and the timezone to Tokyo. (`.github/workflows/renovate.yml` [.github/workflows/renovate.ymlL3-R43](diffhunk://#diff-2f2dcee4f3f279ea8d2f4cd0235f2ab917d8cf1d8e11f4f195a3816afe79af26L3-R43))

Dependency setup modifications:

* Changed the checkout step to use a specific commit reference and updated the step name to use a git clone command. (`.github/workflows/renovate.yml` [.github/workflows/renovate.ymlL3-R43](diffhunk://#diff-2f2dcee4f3f279ea8d2f4cd0235f2ab917d8cf1d8e11f4f195a3816afe79af26L3-R43))
* Replaced the `pnpm` setup with `bun` setup for package management, including updating the related step names and commands. (`.github/workflows/renovate.yml` [.github/workflows/renovate.ymlL3-R43](diffhunk://#diff-2f2dcee4f3f279ea8d2f4cd0235f2ab917d8cf1d8e11f4f195a3816afe79af26L3-R43))
* Modified the Node.js setup step to remove the `pnpm` cache configuration and updated the package installation step to use `bun install`. (`.github/workflows/renovate.yml` [.github/workflows/renovate.ymlL3-R43](diffhunk://#diff-2f2dcee4f3f279ea8d2f4cd0235f2ab917d8cf1d8e11f4f195a3816afe79af26L3-R43))